### PR TITLE
Fix Plex Pass trailer detection

### DIFF
--- a/backend/core/plex_extras.py
+++ b/backend/core/plex_extras.py
@@ -12,13 +12,25 @@ class PlexExtras:
 
     @lru_cache(maxsize=4096)
     def has_trailer(self, tmdb_id: str) -> bool:
-        """Return True if Plex shows at least one 'trailer' extra for this TMDb ID."""
+        """Return True if Plex shows at least one trailer extra for this TMDb ID.
+
+        The Plex API exposes trailers as extras with ``type`` set to ``"clip"``
+        and ``subtype`` set to ``"trailer"``. Older logic only checked that the
+        ``type`` was ``"trailer"`` which no longer matches what Plex returns.
+        This method mirrors the logic used by the
+        ``netplexflix/Missing-Trailer-Downloader-For-Plex`` project by requiring
+        both fields to match.
+        """
         hits = self.server.library.search(guid=f"tmdb://{tmdb_id}")
         if not hits:
             return False
         item = hits[0]
         try:
-            return any(e.type == "trailer" for e in item.extras())
+            return any(
+                getattr(e, "type", None) == "clip"
+                and getattr(e, "subtype", None) == "trailer"
+                for e in item.extras()
+            )
         except Exception as e:  # Plex sometimes 404s on extras()
             log.warning("Plex extras lookup failed for %s: %s", tmdb_id, e)
             return False

--- a/backend/tests/core/test_download_trailers_plex.py
+++ b/backend/tests/core/test_download_trailers_plex.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+import backend.core.tasks.download_trailers as dl
+
+class DummyPlex:
+    def __init__(self, result: bool):
+        self.result = result
+    def has_trailer(self, tmdb_id: str) -> bool:
+        return self.result
+
+
+def _setup_common(monkeypatch, plex_result=False):
+    media = SimpleNamespace(
+        id=1,
+        title="Dummy",
+        is_movie=True,
+        folder_path="/tmp",
+        txdb_id="123",
+        youtube_trailer_id=None,
+    )
+    profile = SimpleNamespace(always_search=False)
+    monkeypatch.setattr(dl.MediaDatabaseManager, "read", lambda self, _: media)
+    monkeypatch.setattr(dl.trailerprofile, "get_trailerprofile", lambda _: profile)
+    monkeypatch.setattr(dl.FilesHandler, "check_folder_exists", lambda _: True)
+    calls = []
+    monkeypatch.setattr(dl.scheduler, "add_job", lambda *a, **k: calls.append((a,k)))
+    monkeypatch.setattr(dl, "_PLEX", DummyPlex(plex_result))
+    return media, profile, calls
+
+
+def test_skip_when_plex_has_trailer(monkeypatch):
+    _, _, calls = _setup_common(monkeypatch, plex_result=True)
+    msg = dl.download_trailer_by_id(1, 1)
+    assert not calls
+    assert "Plex Pass already provides trailer" in msg
+
+
+def test_schedule_when_no_plex_trailer(monkeypatch):
+    _, _, calls = _setup_common(monkeypatch, plex_result=False)
+    msg = dl.download_trailer_by_id(1, 1)
+    assert calls
+    assert "Trailer download started" in msg
+

--- a/backend/tests/core/test_plex_extras.py
+++ b/backend/tests/core/test_plex_extras.py
@@ -1,0 +1,42 @@
+import backend.core.plex_extras as plex_extras
+
+class DummyExtra:
+    def __init__(self, type=None, subtype=None):
+        self.type = type
+        self.subtype = subtype
+
+class DummyItem:
+    def __init__(self, extras):
+        self._extras = extras
+    def extras(self):
+        return self._extras
+
+class DummyLibrary:
+    def __init__(self, items):
+        self._items = items
+    def search(self, **kwargs):
+        return self._items
+
+class DummyServer:
+    def __init__(self, items):
+        self.library = DummyLibrary(items)
+
+
+def _make_server(extras_list):
+    item = DummyItem(extras_list)
+    return DummyServer([item])
+
+
+def test_has_trailer_matches(monkeypatch):
+    server = _make_server([DummyExtra("clip", "trailer")])
+    monkeypatch.setattr(plex_extras, "PlexServer", lambda url, token: server)
+    plex = plex_extras.PlexExtras("http://x", "t")
+    assert plex.has_trailer("42") is True
+
+
+def test_has_trailer_no_match(monkeypatch):
+    server = _make_server([DummyExtra("clip", "featurette"), DummyExtra("trailer", None)])
+    monkeypatch.setattr(plex_extras, "PlexServer", lambda url, token: server)
+    plex = plex_extras.PlexExtras("http://x", "t")
+    assert plex.has_trailer("42") is False
+


### PR DESCRIPTION
## Summary
- update Plex trailer detection to check for clip+trailer extras
- add unit tests for Plex trailer detection and gating logic

## Testing
- `pip install -r backend/requirements.txt`
- `pip install -r .devcontainer/dev-requirements.txt`
- `APP_DATA_DIR=/tmp PYTHONPATH=backend pytest backend/tests/core/test_plex_extras.py backend/tests/core/test_download_trailers_plex.py -q` *(fails: Unable to configure handler 'db')*

------
https://chatgpt.com/codex/tasks/task_e_687acdd851148322ace5a22d9c1d6d0e