### PR TITLE
Improve Plex gating

### DIFF
--- a/backend/core/plex_extras.py
+++ b/backend/core/plex_extras.py
@@ -1,8 +1,14 @@
 from functools import lru_cache
 from plexapi.server import PlexServer
+from plexapi import exceptions as plex_exc
 import logging
+import os
+
+_PLEX = None
+_INIT = False
 
 log = logging.getLogger("trailarr.plex")
+
 
 class PlexExtras:
     """Tiny wrapper that answers: does Plex already have a trailer?"""
@@ -11,26 +17,60 @@ class PlexExtras:
         self.server = PlexServer(url, token)
 
     @lru_cache(maxsize=4096)
-    def has_trailer(self, tmdb_id: str) -> bool:
-        """Return True if Plex shows at least one trailer extra for this TMDb ID.
+    def has_trailer(self, txdb_id: str, is_movie: bool | None = None) -> bool:
+        """Return True if Plex shows at least one trailer extra for this ID.
 
         The Plex API exposes trailers as extras with ``type`` set to ``"clip"``
-        and ``subtype`` set to ``"trailer"``. Older logic only checked that the
-        ``type`` was ``"trailer"`` which no longer matches what Plex returns.
-        This method mirrors the logic used by the
-        ``netplexflix/Missing-Trailer-Downloader-For-Plex`` project by requiring
-        both fields to match.
+        and ``subtype`` set to ``"trailer"``.
+        Searches Plex using ``tmdb://{id}`` for movies and ``tvdb://{id}`` for
+        series. If the first search finds no results, the alternate prefix is
+        tried as a fallback.
         """
-        hits = self.server.library.search(guid=f"tmdb://{tmdb_id}")
+        prefix = "tmdb" if (is_movie or len(txdb_id) == 6) else "tvdb"
+        log.debug(
+            "Searching Plex for %s guid %s://%s",
+            "movie" if is_movie else "series",
+            prefix,
+            txdb_id,
+        )
+        hits = self.server.library.search(guid=f"{prefix}://{txdb_id}")
         if not hits:
-            return False
+            alt_prefix = "tvdb" if prefix == "tmdb" else "tmdb"
+            log.debug("No results. Trying %s://%s", alt_prefix, txdb_id)
+            hits = self.server.library.search(guid=f"{alt_prefix}://{txdb_id}")
+            if not hits:
+                log.debug("No Plex items found for %s", txdb_id)
+                return False
         item = hits[0]
         try:
-            return any(
+            extras = list(item.extras())
+            result = any(
                 getattr(e, "type", None) == "clip"
                 and getattr(e, "subtype", None) == "trailer"
-                for e in item.extras()
+                for e in extras
             )
+            log.debug("Found %d extras for %s -> %s", len(extras), txdb_id, result)
+            return result
         except Exception as e:  # Plex sometimes 404s on extras()
-            log.warning("Plex extras lookup failed for %s: %s", tmdb_id, e)
+            log.warning("Plex extras lookup failed for %s: %s", txdb_id, e)
             return False
+
+
+def get_plex() -> PlexExtras | None:
+    """Lazily create and return a :class:`PlexExtras` instance."""
+    global _PLEX, _INIT
+    if not _INIT:
+        _INIT = True
+        if os.getenv("RESPECT_PLEX_PASS_TRAILERS", "false").lower() == "true":
+            url = os.getenv("PLEX_URL", "http://plex:32400")
+            token = os.getenv("PLEX_TOKEN", "")
+            log.info("Respect Plex Pass: enabled. Connecting to Plex at %s", url)
+            try:
+                _PLEX = PlexExtras(url=url, token=token)
+                log.info("Connected to Plex at %s", url)
+            except plex_exc.BadRequest as e:
+                log.warning("Failed to connect to Plex at %s: %s", url, e)
+                _PLEX = None
+        else:
+            log.info("Respect Plex Pass: disabled")
+    return _PLEX

--- a/backend/tests/core/test_plex_extras.py
+++ b/backend/tests/core/test_plex_extras.py
@@ -1,21 +1,27 @@
 import backend.core.plex_extras as plex_extras
 
+
 class DummyExtra:
     def __init__(self, type=None, subtype=None):
         self.type = type
         self.subtype = subtype
 
+
 class DummyItem:
     def __init__(self, extras):
         self._extras = extras
+
     def extras(self):
         return self._extras
+
 
 class DummyLibrary:
     def __init__(self, items):
         self._items = items
+
     def search(self, **kwargs):
         return self._items
+
 
 class DummyServer:
     def __init__(self, items):
@@ -31,12 +37,20 @@ def test_has_trailer_matches(monkeypatch):
     server = _make_server([DummyExtra("clip", "trailer")])
     monkeypatch.setattr(plex_extras, "PlexServer", lambda url, token: server)
     plex = plex_extras.PlexExtras("http://x", "t")
-    assert plex.has_trailer("42") is True
+    assert plex.has_trailer("42", is_movie=True) is True
 
 
 def test_has_trailer_no_match(monkeypatch):
-    server = _make_server([DummyExtra("clip", "featurette"), DummyExtra("trailer", None)])
+    server = _make_server(
+        [DummyExtra("clip", "featurette"), DummyExtra("trailer", None)]
+    )
     monkeypatch.setattr(plex_extras, "PlexServer", lambda url, token: server)
     plex = plex_extras.PlexExtras("http://x", "t")
-    assert plex.has_trailer("42") is False
+    assert plex.has_trailer("42", is_movie=True) is False
 
+
+def test_has_trailer_tvdb(monkeypatch):
+    server = _make_server([DummyExtra("clip", "trailer")])
+    monkeypatch.setattr(plex_extras, "PlexServer", lambda url, token: server)
+    plex = plex_extras.PlexExtras("http://x", "t")
+    assert plex.has_trailer("12345", is_movie=False) is True

--- a/docs/getting-started/01-first-things/environment-variables.md
+++ b/docs/getting-started/01-first-things/environment-variables.md
@@ -134,6 +134,8 @@ When set to `true`, Trailarr checks Plex for an existing trailer before every
 download attempt. If Plex already provides a trailer (type `clip` and subtype
 `trailer`), Trailarr logs `"Skipped trailer download for [title] - Plex Pass already provides trailer."`
 and does not download or replace the trailer.
+Both movie (TMDb) and series (TVDb) IDs are now supported. Plex is contacted only
+when needed and connection errors are logged instead of crashing the app.
 You can toggle this option from the UI under **Settings > General > Respect Plex Pass**, but a container restart is required for the change to take effect.
 
 ```yaml


### PR DESCRIPTION
## Summary
- lazily initialize Plex connection
- handle tvdb IDs when checking Plex extras
- add logging for Plex pass status
- update docs for Plex pass behavior
- adjust tests

## Testing
- `pytest backend/tests/core/test_plex_extras.py backend/tests/core/test_download_trailers_plex.py -q` *(fails: Unable to configure handler 'db')*

------
https://chatgpt.com/codex/tasks/task_e_687b1f8020b08322a9628e79494e591c