### PR TITLE
Fix Plex GUID lookup

### DIFF
--- a/backend/tests/core/test_plex_extras.py
+++ b/backend/tests/core/test_plex_extras.py
@@ -15,12 +15,23 @@ class DummyItem:
         return self._extras
 
 
-class DummyLibrary:
+class DummySection:
     def __init__(self, items):
         self._items = items
 
+    def getGuid(self, guid):
+        return self._items[0] if self._items else None
+
     def search(self, **kwargs):
         return self._items
+
+
+class DummyLibrary:
+    def __init__(self, items):
+        self._section = DummySection(items)
+
+    def section(self, name):
+        return self._section
 
 
 class DummyServer:


### PR DESCRIPTION
## Summary
- update Plex extras search logic to avoid buggy library search
- update plex extras tests for new lookup method

## Testing
- `PYTHONPATH=backend APP_DATA_DIR=/tmp/trailarr pytest backend/tests/core/test_plex_extras.py -q`
- `PYTHONPATH=backend APP_DATA_DIR=/tmp/trailarr pytest backend/tests/core/test_download_trailers_plex.py -q` *(fails: Unable to configure handler 'db')*

------
https://chatgpt.com/codex/tasks/task_e_687b47141a008322a66e924efb45feab